### PR TITLE
【Fixed】Issue#12  documentsテーブルにcategory, control_number, authorizeカラムを追加 

### DIFF
--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -64,6 +64,6 @@ class DocumentsController < ApplicationController
 
     # Only allow a list of trusted parameters through.
     def document_params
-      params.require(:document).permit(:title, :content, :filepath)
+      params.require(:document).permit(:title, :content, :filepath, :category, :control_number, :authorize)
     end
 end

--- a/app/views/documents/_form.html.erb
+++ b/app/views/documents/_form.html.erb
@@ -26,6 +26,16 @@
     <%= form.file_field :filepath %>
   </div>
 
+  <div class="field">
+    <%= form.label :category %>
+    <%= form.select :category, [["その他文書", 0],["ビジネスプラン", 1]], include_blank: "選択してください" %>
+  </div>
+
+  <div class="field">
+    <%= form.label :authorize %>
+    <%= form.select :authorize, [["未承認", false],["承認", true]], include_blank: "選択してください" %>
+  </div>
+
   <div class="actions">
     <%= form.submit %>
   </div>

--- a/app/views/documents/show.html.erb
+++ b/app/views/documents/show.html.erb
@@ -16,5 +16,15 @@
   <a href="/Users/o541/workspace/tech_document_hub/public/uploads/document/filepath/1/test.pdf">リンク</a>
 </p>
 
+<p>
+  <strong>ファイル種別:</strong>
+  <%= @document.category %>
+</p>
+
+<p>
+  <strong>承認:</strong>
+  <%= @document.authorize %>
+</p>
+
 <%= link_to 'Edit', edit_document_path(@document) %> |
 <%= link_to 'Back', documents_path %>

--- a/db/migrate/20211003104927_add_category_number_authorize_to_documents.rb
+++ b/db/migrate/20211003104927_add_category_number_authorize_to_documents.rb
@@ -1,0 +1,7 @@
+class AddCategoryNumberAuthorizeToDocuments < ActiveRecord::Migration[5.2]
+  def change
+    add_column :documents, :category, :integer, defalt: 0
+    add_column :documents, :control_number, :integer
+    add_column :documents, :authorize, :boolean, defalt: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_10_03_065413) do
+ActiveRecord::Schema.define(version: 2021_10_03_104927) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -21,6 +21,9 @@ ActiveRecord::Schema.define(version: 2021_10_03_065413) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "filepath"
+    t.integer "category"
+    t.integer "control_number"
+    t.boolean "authorize"
   end
 
   create_table "users", force: :cascade do |t|


### PR DESCRIPTION
#12 
categoryとauthorizeはviewも実装済み
control_numberはproduct_idが必要なので、カラムのみ追加してあり、productテーブル作成後に処理を実装する