### PR TITLE
【Fixed】issue#26  pdfファイルへのリンクエラーを解消

### DIFF
--- a/app/views/documents/show.html.erb
+++ b/app/views/documents/show.html.erb
@@ -12,8 +12,7 @@
 
 <p>
   <strong>File:</strong>
-  <%= @document.filepath %>
-  <a href="/Users/o541/workspace/tech_document_hub/public/uploads/document/filepath/1/test.pdf">リンク</a>
+  <%= link_to @document.filepath, @document.filepath.url %>
 </p>
 
 <p>


### PR DESCRIPTION
#26 
aタグからlink_toタグに変更