### PR TITLE
 【Fixed】zipline導入、documentのダウンロード機能実装 issue#35

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -41,3 +41,4 @@ gem 'cancancan'
 gem 'rubocop', require: false
 gem 'carrierwave', '~> 2.0'
 gem 'ransack'
+gem 'zipline'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -298,6 +298,10 @@ GEM
     websocket-extensions (0.1.5)
     xpath (3.2.0)
       nokogiri (~> 1.8)
+    zip_tricks (5.6.0)
+    zipline (1.3.0)
+      actionpack (>= 3.2.1, < 7.0)
+      zip_tricks (>= 4.2.1, < 6.0)
 
 PLATFORMS
   ruby
@@ -329,6 +333,7 @@ DEPENDENCIES
   tzinfo-data
   uglifier (>= 1.3.0)
   web-console (>= 3.3.0)
+  zipline
 
 RUBY VERSION
    ruby 2.6.5p114

--- a/app/views/documents/index.html.erb
+++ b/app/views/documents/index.html.erb
@@ -17,6 +17,8 @@
   <%= f.submit "検索" %>
 <% end %>
 
+<%= link_to '一括ダウンロード', documents_path(format: :zip) %>
+
 <table>
   <thead>
     <tr>


### PR DESCRIPTION
#35 
ziplineを導入して、一括zipダウンロードを実装。

※ ただし、
　ransackの検索で絞り込んでもダウンロードすると全レコードがダウンロードされるバグが発生。
　別issueとして対処。